### PR TITLE
Add tests for the majority of the bindings in the library

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,3 +48,5 @@ jobs:
 
       - name: Run tests
         uses: ./test
+        with:
+          testinput: test

--- a/src/GitHub/Actions/Core.purs
+++ b/src/GitHub/Actions/Core.purs
@@ -111,11 +111,11 @@ foreign import isDebugImpl :: Effect Boolean
 isDebug :: Effect Boolean
 isDebug = isDebugImpl
 
-foreign import debugImpl :: String -> Effect Unit
+foreign import debugImpl :: EffectFn1 String Unit
 
 -- | Writes debug message to user log
 debug :: String -> Effect Unit
-debug = debugImpl
+debug = runEffectFn1 debugImpl
 
 foreign import errorImpl :: EffectFn1 String Unit
 

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -6,6 +6,8 @@ import Control.Monad.Except.Trans (runExceptT)
 import Data.Either (Either(..))
 import Data.Maybe (Maybe(..))
 import Effect (Effect)
+import Effect.Aff (launchAff_)
+import Effect.Class (liftEffect)
 import Effect.Exception (message)
 import GitHub.Actions.Core as Core
 import GitHub.Actions.ToolCache as ToolCache
@@ -13,6 +15,35 @@ import GitHub.Actions.ToolCache as ToolCache
 main :: Effect Unit
 main = do
   Core.info "Starting test action..."
+
+  -- Tests for GitHub.Actions.Core
+  Core.exportVariable { key: "testkey", value: "test" }
+  Core.setOutput { name: "testoutput", value: "test" }
+  Core.setSecret "testoutput"
+  Core.addPath "/test/path"
+  resultCore <- runExceptT do
+    _ <- Core.getInput' "testinput"
+    _ <- Core.getInput { name: "testinput", options: Nothing }
+    Core.getInput { name: "testinput", options: Just { required: true } }
+  case resultCore of
+    Left err -> Core.setFailed (message err)
+    Right _ -> Core.info "No errors in GitHub.Actions.Core ExceptT functions"
+  Core.setCommandEcho false
+  _ <- Core.isDebug
+  Core.debug "Testing debug"
+  Core.error "Testing error"
+  Core.warning "Testing warning"
+  Core.info "Testing info"
+  Core.startGroup "testgroup"
+  Core.endGroup
+  Core.saveState { name: "teststate", value: "test" }
+  _ <- Core.getState "teststate"
+  launchAff_ $ Core.group
+    { name: "testGroup"
+    , fn: liftEffect (pure unit)
+    }
+
+  -- Tests for GitHub.Actions.ToolCache
   result <- runExceptT do
     _ <- ToolCache.find' { toolName: "my-tool", versionSpec: "12.x" }
     ToolCache.find { toolName: "my-tool", versionSpec: "12.x", arch: Just "armv6" }

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -41,7 +41,7 @@ main = do
   _ <- Core.getState "teststate"
   launchAff_ $ Core.group
     { name: "testGroup"
-    , fn: liftEffect (pure unit)
+    , fn: liftEffect (Core.info "In testGroup")
     }
 
   -- Tests for GitHub.Actions.Cache

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -11,6 +11,7 @@ import Effect.Class (liftEffect)
 import Effect.Exception (message)
 import GitHub.Actions.Cache as Cache
 import GitHub.Actions.Core as Core
+import GitHub.Actions.Exec as Exec
 import GitHub.Actions.ToolCache as ToolCache
 
 main :: Effect Unit
@@ -57,6 +58,16 @@ main = do
     _ <- Cache.restoreCache { paths: [], primaryKey: "restorecache", restoreKeys: Nothing, options: Nothing }
     _ <- Cache.restoreCache { paths: [], primaryKey: "restorecache", restoreKeys: Just [ "a" ], options: Nothing }
     Cache.restoreCache { paths: [], primaryKey: "restorecaceh", restoreKeys: Just [ "a" ], options: Just (Cache.defaultDownloadOptions { useAzureSdk = Just true, downloadConcurrency = Just true, timeoutInMs = Just 10.0 })}
+
+  -- Tests for GitHub.Actions.Exec
+  let
+    execCb = case _ of
+      Left err -> Core.setFailed (message err)
+      Right _ -> Core.info "No errors in exec"
+  runAff_ execCb $ runExceptT do
+    _ <- Exec.exec' "ls"
+    _ <- Exec.exec { command: "ls", args: Just [ "-a" ], options: Nothing }
+    Exec.exec { command: "ls", args: Just [ "-a" ], options: Just (Exec.defaultExecOptions { delay = Just 10.0 })}
 
   -- Tests for GitHub.Actions.ToolCache
   result <- runExceptT do

--- a/test/action.yml
+++ b/test/action.yml
@@ -3,3 +3,10 @@ description: 'Test out bindings in this library'
 runs:
   using: 'node12'
   main: '../dist/index.js'
+inputs:
+  testinput:
+    description: 'Test input for test action'
+    required: true
+outputs:
+  testoutput:
+    description: 'Test output for test action'


### PR DESCRIPTION
**Description of the change**
Following up on #8, adding code to the test action which exercises (almost) all bindings.

The tests work by calling the bindings in almost all variations, making sure that the binding was written correctly (making sure the FFI implementation is correct and the types were implemented properly).  This doesn't guarantee anything about the underlying library - only that the bindings communicate with it properly.

At this point the only know bindings that are not excersized are `extract7z` and `extractXar`, as I couldn't find easy ways to get those files.  However, those bindings are basically the same as `extractTar` and `extractZip`, which are defined properly.