### PR TITLE
Upgrade actions dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ New features:
 
 Bugfixes:
 
+- GitHub `@actions/*` dependencies upgraded for post-October 2020 compatibility @jisantuc
+
 Other improvements:
 
 ## [0.0.0] - 2020-01-01

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ New features:
 
 Bugfixes:
 
-- GitHub `@actions/*` dependencies upgraded for post-October 2020 compatibility. This affects the functionality of `addPath`, which is [formally deprecated](https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/) to avoid a security vulnerability. [#13](https://github.com/purescript-contrib/purescript-github-actions-toolkit/pull/13) @jisantuc
+- GitHub `@actions/*` dependencies upgraded for post-October 2020 compatibility. This affects the functionality of `addPath`, which is [formally deprecated](https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/) to avoid a security vulnerability. (#13 by @jisantuc)
 
 Other improvements:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ New features:
 
 Bugfixes:
 
-- GitHub `@actions/*` dependencies upgraded for post-October 2020 compatibility @jisantuc
+- GitHub `@actions/*` dependencies upgraded for post-October 2020 compatibility. This affects the functionality of `addPath`, which is [formally deprecated](https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/) to avoid a security vulnerability. [#13](https://github.com/purescript-contrib/purescript-github-actions-toolkit/pull/13) @jisantuc
 
 Other improvements:
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "scripts": {
-    "build": "eslint src && spago build --purs-args '--censor-lib --strict --censor-codes='UserDefinedWarning'",
+    "build": "eslint src && spago build --purs-args '--censor-lib --strict --censor-codes=UserDefinedWarning'",
     "test": "spago test --no-install"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -9,10 +9,10 @@
     "eslint": "^7.6.0"
   },
   "dependencies": {
-    "@actions/cache": "^1.0.2",
+    "@actions/cache": "^1.0.6",
     "@actions/core": "^1.2.6",
     "@actions/exec": "^1.0.4",
     "@actions/io": "^1.0.2",
-    "@actions/tool-cache": "^1.6.0"
+    "@actions/tool-cache": "^1.6.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "scripts": {
-    "build": "eslint src && spago build --purs-args '--censor-lib --filter-codes=UserDefinedWarning --strict'",
+    "build": "eslint src && spago build --purs-args '--censor-lib --strict'",
     "test": "spago test --no-install"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@actions/cache": "^1.0.2",
-    "@actions/core": "^1.2.5",
+    "@actions/core": "^1.2.6",
     "@actions/exec": "^1.0.4",
     "@actions/io": "^1.0.2",
     "@actions/tool-cache": "^1.6.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "scripts": {
-    "build": "eslint src && spago build --purs-args '--censor-lib --strict'",
+    "build": "eslint src && spago build --purs-args '--censor-lib --strict --censor-codes='UserDefinedWarning'",
     "test": "spago test --no-install"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "scripts": {
-    "build": "eslint src && spago build --purs-args '--censor-lib --strict'",
+    "build": "eslint src && spago build --purs-args '--censor-lib --filter-codes=UserDefinedWarning --strict'",
     "test": "spago test --no-install"
   },
   "devDependencies": {

--- a/src/GitHub/Actions/Core.purs
+++ b/src/GitHub/Actions/Core.purs
@@ -23,7 +23,6 @@ module GitHub.Actions.Core
   ) where
 
 import Prelude
-
 import Control.Monad.Error.Class (try)
 import Control.Monad.Except.Trans (ExceptT(..))
 import Control.Promise (Promise, fromAff, toAffE)
@@ -32,6 +31,7 @@ import Effect (Effect)
 import Effect.Aff (Aff)
 import Effect.Exception (Error)
 import Effect.Uncurried (EffectFn1, EffectFn2, runEffectFn1, runEffectFn2)
+import Prim.TypeError (class Warn, Text)
 
 -- | Interface for getInput options
 -- | required: Whether the input is required. If required and not present, will throw
@@ -57,7 +57,9 @@ setSecret = runEffectFn1 setSecretImpl
 foreign import addPathImpl :: EffectFn1 String Unit
 
 -- | Prepends input path to the PATH (for this action and future actions)
-addPath :: String -> Effect Unit
+addPath ::
+  Warn (Text "addPath is deprecated due to a security vulnerability and will be removed in the next release.") =>
+  String -> Effect Unit
 addPath = runEffectFn1 addPathImpl
 
 foreign import getInput1Impl :: EffectFn1 String String


### PR DESCRIPTION
**Description of the change**
This PR upgrades `@actions/*` where possible. The reason to do so is that GitHub changed the rules around [`add-path`](https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/) to address a security vulnerability.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a link to this PR and your username
- [x] Linked any existing issues or proposals that this pull request should close
- [x] Updated or added relevant documentation in the README and/or documentation directory
- ~Added a test for the contribution (if applicable)~ I believe that the existing `addPath` test should verify that this is fine
