### PR TITLE
Update for PureScript 0.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,46 @@ Notable changes to this project are documented in this file. The format is based
 
 ## [Unreleased]
 
-Breaking changes (😱!!!):
+Breaking changes:
 
 New features:
 
 Bugfixes:
 
-- GitHub `@actions/*` dependencies upgraded for post-October 2020 compatibility. This affects the functionality of `addPath`, which is [formally deprecated](https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/) to avoid a security vulnerability. (#13 by @jisantuc)
+Other improvements:
+
+## [v0.3.0](https://github.com/purescript-contrib/purescript-github-actions-toolkit/releases/tag/v0.3.0) - 2021-04-18
+
+Breaking changes:
+
+- Added support for PureScript 0.14 and dropped support for other compiler versions. (#16 by @thomashoneyman)
+- Updated GitHub `@actions/*` dependencies for post-October 2020 compatibility. (#13 by @jisantuc)
+
+## [v0.2.2](https://github.com/purescript-contrib/purescript-github-actions-toolkit/releases/tag/v0.2.2) - 2021-02-03
 
 Other improvements:
 
-## [0.0.0] - 2020-01-01
+- Added tests for the majority of bindings in the library (#9 by @colinwahl)
+- Updated the location of the changelog and contributing files (#11 by @maxdeviant)
+- Bumped the versions of @actions/core, @actions/cache, and @actions/tool-cache
+
+## [v0.2.0](https://github.com/purescript-contrib/purescript-github-actions-toolkit/releases/tag/v0.2.0) - 2020-09-22
+
+Bugfixes:
+
+- Fixed a typo on the FFI for the `find` function (#8 by @colinwahl)
+
+Other improvements
+
+- Added a test action (#8 by @colinwahl)
+- Added CI for all push / pull requests (#6 by @colinwahl)
+
+## [v0.1.0](https://github.com/purescript-contrib/purescript-github-actions-toolkit/releases/tag/v0.1.0) - 2020-09-09
+
+Initial release of GitHub Actions Toolkit bindings. This features full bindings to the following packages:
+
+- @actions/core (as GitHub.Actions.Core)
+- @actions/exec (as GitHub.Actions.Exec)
+- @actions/io (as GitHub.Actions.IO)
+- @actions/tool-cache (as GitHub.Actions.ToolCache)
+- @actions/cache (as GitHub.Actions.Cache)

--- a/bower.json
+++ b/bower.json
@@ -14,14 +14,14 @@
         "output"
     ],
     "dependencies": {
-        "purescript-aff": "^v5.1.2",
-        "purescript-aff-promise": "^v2.1.0",
-        "purescript-effect": "^v2.0.1",
-        "purescript-foreign-object": "^v2.0.3",
-        "purescript-node-buffer": "^v6.0.0",
-        "purescript-node-path": "^v3.0.0",
-        "purescript-node-streams": "^v4.0.1",
-        "purescript-nullable": "^v4.1.1",
-        "purescript-transformers": "^v4.2.0"
+        "purescript-aff": "^v6.0.0",
+        "purescript-aff-promise": "^v3.0.0",
+        "purescript-effect": "^v3.0.0",
+        "purescript-foreign-object": "^v3.0.0",
+        "purescript-node-buffer": "^v7.0.0",
+        "purescript-node-path": "^v4.0.0",
+        "purescript-node-streams": "^v5.0.0",
+        "purescript-nullable": "^v5.0.0",
+        "purescript-transformers": "^v5.0.0"
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "private": true,
   "scripts": {
-    "build": "eslint src && spago build --purs-args '--censor-lib --strict --censor-codes=UserDefinedWarning'",
+    "build": "eslint src && spago build --purs-args '--censor-lib --strict'",
     "test": "spago test --no-install"
   },
   "devDependencies": {
-    "@vercel/ncc": "^0.24.1",
-    "eslint": "^7.6.0"
+    "@vercel/ncc": "^0.27.0",
+    "eslint": "^7.22.0"
   },
   "dependencies": {
     "@actions/cache": "^1.0.6",

--- a/packages.dhall
+++ b/packages.dhall
@@ -1,4 +1,4 @@
 let upstream =
-      https://github.com/purescript/package-sets/releases/download/psc-0.14.0/packages.dhall sha256:710b53c085a18aa1263474659daa0ae15b7a4f453158c4f60ab448a6b3ed494e
+      https://github.com/purescript/package-sets/releases/download/psc-0.14.0-20210318/packages.dhall sha256:98bbacd65191cef354ecbafa1610be13e183ee130491ab9c0ef6e3d606f781b5
 
 in  upstream

--- a/src/GitHub/Actions/Core.purs
+++ b/src/GitHub/Actions/Core.purs
@@ -31,7 +31,6 @@ import Effect (Effect)
 import Effect.Aff (Aff)
 import Effect.Exception (Error)
 import Effect.Uncurried (EffectFn1, EffectFn2, runEffectFn1, runEffectFn2)
-import Prim.TypeError (class Warn, Text)
 
 -- | Interface for getInput options
 -- | required: Whether the input is required. If required and not present, will throw
@@ -57,9 +56,7 @@ setSecret = runEffectFn1 setSecretImpl
 foreign import addPathImpl :: EffectFn1 String Unit
 
 -- | Prepends input path to the PATH (for this action and future actions)
-addPath ::
-  Warn (Text "addPath is deprecated due to a security vulnerability and will be removed in the next release.") =>
-  String -> Effect Unit
+addPath :: String -> Effect Unit
 addPath = runEffectFn1 addPathImpl
 
 foreign import getInput1Impl :: EffectFn1 String String


### PR DESCRIPTION
**Description of the change**

This updates the package for PureScript 0.14 (by updating its dependencies). It also takes two other actions:

- It removes the deprecation warning from `addPath`, because after reading through [the GitHub security announcement](https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/) again I see that it's not deprecated -- it just requires that we upgrade to 1.2.6 of the `core` package.
- It updates the changelog with prior releases and in preparation for the next release.

Fixes #15.

---

**Checklist:**

- ~Added the change to the changelog's "Unreleased" section with a link to this PR and your username~
- [x] Linked any existing issues or proposals that this pull request should close
- ~Updated or added relevant documentation in the README and/or documentation directory~
- ~Added a test for the contribution (if applicable)~
